### PR TITLE
feat : jwt 기반 회원가입/로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,20 +24,46 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.postgresql:postgresql:42.7.3'
+	// Spring Boot 기본 의존성
+	implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+	implementation "org.springframework.boot:spring-boot-starter-security"
+	implementation "org.springframework.boot:spring-boot-starter-web"
+	implementation "org.postgresql:postgresql:42.7.3"
 
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	runtimeOnly 'org.postgresql:postgresql'
-	implementation("io.github.cdimascio:java-dotenv:5.2.2") // 환경변수 파일 읽기 위한 라이브러리 추가
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// Lombok
+	compileOnly "org.projectlombok:lombok"
+	annotationProcessor "org.projectlombok:lombok"
+
+	// Spring Validation
+	implementation "org.springframework.boot:spring-boot-starter-validation"
+
+	implementation('org.modelmapper:modelmapper:2.4.4')
+
+	// Test 관련 의존성
+	testImplementation "org.springframework.boot:spring-boot-starter-test"
+	testImplementation "org.springframework.security:spring-security-test"
+	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+
+	// 환경 변수 파일(.env) 읽기 위한 라이브러리
+	implementation "io.github.cdimascio:java-dotenv:5.2.2"
+
+	// QueryDSL 추가
+	//implementation "com.querydsl:querydsl-jpa:5.0.0"
+	//implementation "com.querydsl:querydsl-apt:5.0.0"
+
+	// Jakarta JPA API (Spring Boot 3.x 이상에서 필요)
+	//implementation "jakarta.persistence:jakarta.persistence-api:3.1.0"
+	//implementation "jakarta.annotation:jakarta.annotation-api:2.1.0"
+
+	// QueryDSL Annotation Processor
+	//annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
+

--- a/src/main/java/com/teamsparta14/order_service/OrderServiceApplication.java
+++ b/src/main/java/com/teamsparta14/order_service/OrderServiceApplication.java
@@ -2,8 +2,10 @@ package com.teamsparta14.order_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class OrderServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/teamsparta14/order_service/config/ModelMapperConfig.java
+++ b/src/main/java/com/teamsparta14/order_service/config/ModelMapperConfig.java
@@ -1,0 +1,11 @@
+package com.teamsparta14.order_service.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}

--- a/src/main/java/com/teamsparta14/order_service/config/PropertyConfig.java
+++ b/src/main/java/com/teamsparta14/order_service/config/PropertyConfig.java
@@ -1,4 +1,4 @@
-package com.teamsparta14.order_service.global;
+package com.teamsparta14.order_service.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;

--- a/src/main/java/com/teamsparta14/order_service/config/SecurityConfig.java
+++ b/src/main/java/com/teamsparta14/order_service/config/SecurityConfig.java
@@ -1,0 +1,101 @@
+package com.teamsparta14.order_service.config;
+
+import com.teamsparta14.order_service.user.jwt.CustomLogoutFilter;
+import com.teamsparta14.order_service.user.jwt.JWTFilter;
+import com.teamsparta14.order_service.user.jwt.JWTUtil;
+import com.teamsparta14.order_service.user.jwt.LoginFilter;
+import com.teamsparta14.order_service.user.repository.RefreshRepository;
+import com.teamsparta14.order_service.user.service.TokenReissueService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    //AuthenticationManager가 인자로 받을 AuthenticationConfiguraion 객체 생성자 주입
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JWTUtil jwtUtil;
+    private final TokenReissueService tokenReissueService;
+    private final RefreshRepository refreshRepository;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        // Custom LoginFilter 등록
+        LoginFilter loginFilter = new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, tokenReissueService);
+        loginFilter.setFilterProcessesUrl("/api/auth/login"); // 엔드포인트를 /api/login으로 변경
+
+        http
+                .cors((cors)-> cors
+                        .configurationSource(new CorsConfigurationSource(){
+
+                            @Override
+                            public CorsConfiguration getCorsConfiguration(HttpServletRequest request){
+                                CorsConfiguration configuration = new CorsConfiguration();
+
+                                configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+                                configuration.setAllowedMethods(Collections.singletonList("*"));
+                                configuration.setAllowCredentials(true);
+                                configuration.setAllowedHeaders(Collections.singletonList("*"));
+                                configuration.setMaxAge(3600L);
+
+                                configuration.setExposedHeaders(Arrays.asList("Authorization", "access"));
+                                return configuration;
+                            }
+
+                        }));
+
+        http
+                .csrf(csrf -> csrf.disable())  // CSRF 보호 비활성화 (POST 요청 허용)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/join/**", "/api/auth/login").permitAll()  // 회원가입은 인증 없이 가능
+                        .anyRequest().authenticated()  // 그 외 모든 요청은 인증 필요
+                )
+                .formLogin(login -> login.disable())  // 기본 로그인 폼 비활성화
+                .httpBasic(basic -> basic.disable()); // HTTP Basic 인증 비활성화
+
+        http
+                .logout((auth)->auth.disable()); // 기본 로그아웃 필터 비활성화
+
+        http
+                .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);
+
+        http
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, tokenReissueService), UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshRepository), LogoutFilter.class);
+
+        //세션 설정
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/teamsparta14/order_service/domain/BaseEntity.java
+++ b/src/main/java/com/teamsparta14/order_service/domain/BaseEntity.java
@@ -23,7 +23,7 @@ public abstract class BaseEntity{
     private LocalDateTime createdAt;
 
     @CreatedBy
-    @Column(updatable = false, length = 100)
+    @Column(updatable = false,length = 100)
     private String createdBy;
 
     @LastModifiedDate

--- a/src/main/java/com/teamsparta14/order_service/global/enums/Role.java
+++ b/src/main/java/com/teamsparta14/order_service/global/enums/Role.java
@@ -1,0 +1,5 @@
+package com.teamsparta14.order_service.global.enums;
+
+public enum Role {
+    USER,OWNER,MANAGER,MASTER
+}

--- a/src/main/java/com/teamsparta14/order_service/global/exception/BaseException.java
+++ b/src/main/java/com/teamsparta14/order_service/global/exception/BaseException.java
@@ -1,0 +1,58 @@
+package com.teamsparta14.order_service.global.exception;
+import com.teamsparta14.order_service.global.response.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+
+    private final ResponseCode errorCode;
+
+    // 기본 생성자에서는 일반적인 에러 코드를 사용
+    public BaseException() {
+        super(ResponseCode.INTERNAL_SERVER_ERROR.getMessage());
+        this.errorCode = ResponseCode.INTERNAL_SERVER_ERROR;
+    }
+
+    // 에러 메시지를 받는 생성자
+    public BaseException(String message) {
+        super(message);
+        this.errorCode = ResponseCode.INTERNAL_SERVER_ERROR;
+    }
+
+    // 에러 메시지와 원인을 받는 생성자
+    public BaseException(String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = ResponseCode.INTERNAL_SERVER_ERROR;
+    }
+
+    // 원인만을 받는 생성자
+    public BaseException(Throwable cause) {
+        super(cause);
+        this.errorCode = ResponseCode.INTERNAL_SERVER_ERROR;
+    }
+
+    // 에러 코드를 지정하는 생성자
+    public BaseException(ResponseCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    // 에러 코드와 메시지를 받는 생성자
+    public BaseException(ResponseCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    // 에러 코드, 메시지, 원인을 받는 생성자
+    public BaseException(ResponseCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    // 에러 코드와 원인을 받는 생성자
+    public BaseException(ResponseCode errorCode, Throwable cause) {
+        super(cause);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/teamsparta14/order_service/user/controller/UserController.java
+++ b/src/main/java/com/teamsparta14/order_service/user/controller/UserController.java
@@ -1,0 +1,56 @@
+package com.teamsparta14.order_service.user.controller;
+
+import com.teamsparta14.order_service.global.response.ApiResponse;
+import com.teamsparta14.order_service.global.response.ResponseCode;
+import com.teamsparta14.order_service.user.dto.UserRequestDTO;
+import com.teamsparta14.order_service.user.dto.UserResponseDTO;
+import com.teamsparta14.order_service.user.entity.UserEntity;
+import com.teamsparta14.order_service.user.service.TokenReissueService;
+import com.teamsparta14.order_service.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+    private final TokenReissueService tokenReissueService;
+
+    //유저 회원가입
+    @PostMapping("/api/auth/join/user")
+    public void user_join(@RequestBody @Valid UserRequestDTO userRequestDTO){
+        userService.user_save(userRequestDTO);
+    }
+
+    //관리자 회원가입
+    @PostMapping("/api/auth/join/master")
+    public void master_join(@RequestBody @Valid UserRequestDTO userRequestDTO) {userService.master_save(userRequestDTO);}
+
+    //가게주인 회원가입
+    @PostMapping("/api/auth/join/owner")
+    public void owner_join(@RequestBody @Valid UserRequestDTO userRequestDTO) {userService.owner_save(userRequestDTO);}
+
+    //매니저 회원가입
+    @PostMapping("/api/auth/join/manager")
+    public void manager_join(@RequestBody @Valid UserRequestDTO userRequestDTO) {userService.manager_save(userRequestDTO);}
+
+    //유저 조회
+    @GetMapping("/api/user/list/{username}")
+    public UserResponseDTO user_list(@PathVariable("username") String username) {
+        return userService.findUser(username);
+    }
+
+    //토큰 재발급
+    @PostMapping("/api/auth/token/reissue")
+    public ResponseEntity<ApiResponse<String>> reissue(HttpServletRequest request, HttpServletResponse response){
+        return tokenReissueService.token_reissue(request,response);
+    }
+
+
+}

--- a/src/main/java/com/teamsparta14/order_service/user/dto/CustomUserDetails.java
+++ b/src/main/java/com/teamsparta14/order_service/user/dto/CustomUserDetails.java
@@ -1,0 +1,64 @@
+package com.teamsparta14.order_service.user.dto;
+
+
+import com.teamsparta14.order_service.global.enums.Role;
+import com.teamsparta14.order_service.user.entity.UserEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final UserEntity userEntity;
+
+    public CustomUserDetails(UserEntity userEntity){
+        this.userEntity = userEntity;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return userEntity.getRole().toString();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return userEntity.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return userEntity.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/teamsparta14/order_service/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/teamsparta14/order_service/user/dto/UserRequestDTO.java
@@ -1,0 +1,33 @@
+package com.teamsparta14.order_service.user.dto;
+
+import com.teamsparta14.order_service.global.enums.Role;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class UserRequestDTO {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    @NotBlank(message = "아이디는 필수 입력 값입니다.")
+    @Size(min= 4, max= 10, message = "아이디는 최소 4자 이상 최대 10자 이하입니다.")
+    @Pattern(regexp = "^[a-z0-9]+$", message = "username은 알파벳 소문자(a~z)와 숫자(0~9)만 포함해야 합니다.")
+    private String username;
+
+    @Size(min = 8, max = 15, message = "password는 최소 8자 이상, 15자 이하이어야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+            message = "비밀번호는 최소 8자 이상, 15자 이하이며 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자를 포함해야 합니다."
+    )
+    private String password;
+
+    @NotBlank(message = "닉네임을 반드시 입력해주세요")
+    private String userNickname;
+
+}

--- a/src/main/java/com/teamsparta14/order_service/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/teamsparta14/order_service/user/dto/UserResponseDTO.java
@@ -1,0 +1,13 @@
+package com.teamsparta14.order_service.user.dto;
+
+import com.teamsparta14.order_service.global.enums.Role;
+import lombok.Data;
+
+@Data
+public class UserResponseDTO {
+    private Long id;
+    private String username;
+    private String password;
+    private String userNickname;
+    private Role role;
+}

--- a/src/main/java/com/teamsparta14/order_service/user/entity/RefreshEntity.java
+++ b/src/main/java/com/teamsparta14/order_service/user/entity/RefreshEntity.java
@@ -1,0 +1,21 @@
+package com.teamsparta14.order_service.user.entity;
+
+import com.teamsparta14.order_service.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "refresh")
+public class RefreshEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+    private String refresh;
+    private String expiration;
+}
+

--- a/src/main/java/com/teamsparta14/order_service/user/entity/UserEntity.java
+++ b/src/main/java/com/teamsparta14/order_service/user/entity/UserEntity.java
@@ -1,0 +1,29 @@
+package com.teamsparta14.order_service.user.entity;
+import com.teamsparta14.order_service.domain.BaseEntity;
+import com.teamsparta14.order_service.global.enums.Role;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter @Setter
+@Table(name="member")
+public class UserEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String userNickname;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+}

--- a/src/main/java/com/teamsparta14/order_service/user/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/teamsparta14/order_service/user/jwt/CustomLogoutFilter.java
@@ -1,0 +1,111 @@
+package com.teamsparta14.order_service.user.jwt;
+
+
+import com.teamsparta14.order_service.user.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    public CustomLogoutFilter(JWTUtil jwtUtil, RefreshRepository refreshRepository){
+        this.jwtUtil = jwtUtil;
+        this.refreshRepository = refreshRepository;
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException{
+        doFilter((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse, filterChain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        //logout 경로로 요청이 들어왔는지 검사하고 안되었으면 다음 필터 실행
+        String requestUri = request.getRequestURI();
+        if(!requestUri.matches("^\\/api\\/auth\\/logout$")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //요청 방식이 POST인지 검사하고 아니면 다음 필터 실행
+        String requestMethod = request.getMethod();
+        if(!requestMethod.equals("POST")){
+            filterChain.doFilter(request,response);
+            return;
+        }
+
+        //refresh 토큰을 가져오기
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        System.out.println(cookies);
+        if(cookies != null){
+            for(Cookie cookie : cookies) {
+                if(cookie.getName().equals("refresh")){
+                    refresh = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+
+        //refresh 토큰 체크
+        if(refresh == null){
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //refresh token 만료되었는지 확인
+        try{
+            jwtUtil.isExpired(refresh);
+        }catch (ExpiredJwtException e){
+            //만료 되었으면 상태 반환
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().write("Token has expired");
+            return;
+        }
+
+        //토큰이 refresh 인지 확인
+        String category = jwtUtil.getCategory(refresh);
+        if(!category.equals("refresh")){
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //DB에 refresh 토큰이 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if(!isExist){
+
+            //에러메세지나 적절한 만료되었다는 메세지를 전달해주면 된다
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //로그아웃 진행
+        //refresh db에서 토큰 제거
+        refreshRepository.deleteByRefresh(refresh);
+
+        //Refresh 토큰 삭제 후, cookie값을 null로 처리해준다.
+        //유효시간 값과 path 값, credential 값 등 여러가지를 처리해준다.
+        Cookie cookie = new Cookie("refresh",null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+
+
+    }
+
+
+}

--- a/src/main/java/com/teamsparta14/order_service/user/jwt/JWTFilter.java
+++ b/src/main/java/com/teamsparta14/order_service/user/jwt/JWTFilter.java
@@ -1,0 +1,83 @@
+package com.teamsparta14.order_service.user.jwt;
+
+
+import com.teamsparta14.order_service.global.enums.Role;
+import com.teamsparta14.order_service.user.dto.CustomUserDetails;
+import com.teamsparta14.order_service.user.entity.UserEntity;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+//요청에 대해서 한번만 동작하는 OncePerRequestFilter를 상속받는다
+public class JWTFilter extends OncePerRequestFilter {
+
+    JWTUtil jwtUtil;
+    public JWTFilter(JWTUtil jwtUtil){
+        this.jwtUtil = jwtUtil;
+    }
+    //내부 필터에 대한 특정 구현을 진행
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        //헤더에서 access 에 담긴 토큰을 꺼낸다
+        String accessToken = request.getHeader("access");
+
+        //토큰이 없다면 다음 필터로 넘김
+        if(accessToken == null){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+        try{
+            jwtUtil.isExpired(accessToken);
+        }catch (ExpiredJwtException e){
+
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("access token expired");
+
+            //res status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        //토큰이 access 토큰인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(accessToken);
+
+        if(!category.equals("access")){
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("invalid access token");
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        //user정보 가져오기
+        String username = jwtUtil.getUsername(accessToken);
+        String role = jwtUtil.getRole(accessToken);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setUsername(username);
+        userEntity.setRole(Role.valueOf(role));
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(userEntity);
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request,response);
+    }
+}
+

--- a/src/main/java/com/teamsparta14/order_service/user/jwt/JWTUtil.java
+++ b/src/main/java/com/teamsparta14/order_service/user/jwt/JWTUtil.java
@@ -1,0 +1,52 @@
+package com.teamsparta14.order_service.user.jwt;
+
+
+import com.teamsparta14.order_service.global.enums.Role;
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+
+//JWTUtil 0.12.3 version
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret){
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    //아래 2개의 메서드는 토큰을 검증하는 로직을 담고 있다. getUsername, isExpired
+    public String getUsername(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username",String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Boolean isExpired(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String getCategory(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
+    public String createJwt(String category, String username, String role, Long expiredMs){
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}
+

--- a/src/main/java/com/teamsparta14/order_service/user/jwt/LoginFilter.java
+++ b/src/main/java/com/teamsparta14/order_service/user/jwt/LoginFilter.java
@@ -1,0 +1,146 @@
+package com.teamsparta14.order_service.user.jwt;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamsparta14.order_service.global.enums.Role;
+import com.teamsparta14.order_service.global.exception.BaseException;
+import com.teamsparta14.order_service.global.response.ApiResponse;
+import com.teamsparta14.order_service.global.response.ResponseCode;
+import com.teamsparta14.order_service.user.service.TokenReissueService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final TokenReissueService tokenReissueService;
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+
+    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil, TokenReissueService tokenReissueService) {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+        this.tokenReissueService = tokenReissueService;
+        //spring security는 대부분의 로직이 필터 단에서 동작하게 된다. 로그인 또한, 필터에서 처리되고, (자동으로 엔드포인트는 "/login" 이 된다.)
+        //UsernamePasswordAuthenticationFilter에서 매핑되어 처리된다. 이 필터를 상속받아 LoginFilter를 만들게 된다.
+        //security에서 설정해주는 기본 url("/login")을 /api/auth/login으로 변경
+        setFilterProcessesUrl("/api/auth/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        //클라이언트 요청으로 부터 username, password를 추출한다.
+//        String username = obtainUsername(request);
+//        String password = obtainPassword(request);
+        String username = null;
+        String password = null;
+
+        // JSON 형식인지 확인
+        if (request.getContentType() != null && request.getContentType().contains("application/json")) {
+            try {
+                // JSON 데이터를 읽어서 파싱
+                ObjectMapper objectMapper = new ObjectMapper();
+                Map<String, String> requestMap = objectMapper.readValue(request.getInputStream(), Map.class);
+
+                username = requestMap.get("username");
+                password = requestMap.get("password");
+            } catch (IOException e) {
+                throw new AuthenticationServiceException("Failed to parse JSON request", e);
+            }
+        } else {
+            // 기본 form-urlencoded 방식 처리
+            username = obtainUsername(request);
+            password = obtainPassword(request);
+        }
+
+        if (username == null || password == null) {
+            throw new AuthenticationServiceException("Username or Password is missing");
+        }
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password);
+
+        return authenticationManager.authenticate(authToken);
+
+    }
+
+    //로그인 성공시 실행하는 메서드 (여기서 jwt를 발급하면 된다)
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException{
+        //유저 이름 찾기
+        String username = authentication.getName();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+
+        if (!iterator.hasNext()) {
+            throw new BaseException("User not found");
+        }
+
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+        String access = jwtUtil.createJwt("access",username, role, 600000L*60*24*100); // 24시간 *100 = 100일. 테스트를 위해 기한 늘림
+        String refresh = jwtUtil.createJwt("refresh", username, role,86400000L*100); // 24시간 *100 = 100일
+
+        tokenReissueService.RefreshTokenSave(username,refresh,86400000L*100);
+
+        // 로그인 성공
+        ResponseEntity<ApiResponse<String>> responseBody = ResponseEntity.ok().body(ApiResponse.success("로그인을 성공하였습니다."));
+
+        response.setHeader("access", access);
+        response.addCookie(createCookie("refresh", refresh));
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // JSON 변환 후 출력
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody.getBody()));
+
+    }
+
+    //로그인 실패시 실행하는 메서드
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, org.springframework.security.core.AuthenticationException failed) throws IOException{
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // 실패 응답 객체 생성
+        ResponseEntity<ApiResponse<String>> responseBody = ResponseEntity.badRequest().body(ApiResponse.fail(ResponseCode.BAD_REQUEST, "아이디 혹은 비밀번호를 다시 입력해주세요"));
+
+        // JSON 변환 후 출력
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody.getBody()));
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+//        cookie.setSecure(true); // https일 경우 설정
+//        cookie.setPath("/"); // 쿠키의 적용 범위 설정
+
+        //js로 쿠키에 접근 못하게 함
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}
+

--- a/src/main/java/com/teamsparta14/order_service/user/repository/RefreshRepository.java
+++ b/src/main/java/com/teamsparta14/order_service/user/repository/RefreshRepository.java
@@ -1,0 +1,14 @@
+package com.teamsparta14.order_service.user.repository;
+
+
+import com.teamsparta14.order_service.user.entity.RefreshEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface RefreshRepository extends JpaRepository<RefreshEntity, Long> {
+    Boolean existsByRefresh(String refresh);
+
+    @Transactional
+    void deleteByRefresh(String refresh);
+}
+

--- a/src/main/java/com/teamsparta14/order_service/user/repository/UserRepository.java
+++ b/src/main/java/com/teamsparta14/order_service/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.teamsparta14.order_service.user.repository;
+
+import com.teamsparta14.order_service.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByUsername(String username);
+}

--- a/src/main/java/com/teamsparta14/order_service/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/teamsparta14/order_service/user/service/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.teamsparta14.order_service.user.service;
+
+import com.teamsparta14.order_service.user.dto.CustomUserDetails;
+import com.teamsparta14.order_service.user.entity.UserEntity;
+import com.teamsparta14.order_service.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<UserEntity> memberData =  userRepository.findByUsername(username);
+
+        if(memberData.isPresent()){
+            return new CustomUserDetails(memberData.get());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/teamsparta14/order_service/user/service/TokenReissueService.java
+++ b/src/main/java/com/teamsparta14/order_service/user/service/TokenReissueService.java
@@ -1,0 +1,111 @@
+package com.teamsparta14.order_service.user.service;
+
+import com.teamsparta14.order_service.global.response.ApiResponse;
+import com.teamsparta14.order_service.global.response.ResponseCode;
+import com.teamsparta14.order_service.user.entity.RefreshEntity;
+import com.teamsparta14.order_service.user.jwt.JWTUtil;
+import com.teamsparta14.order_service.user.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class TokenReissueService {
+
+    private final RefreshRepository refreshRepository;
+    private final JWTUtil jwtUtil;
+
+    //토큰 재발급
+    public ResponseEntity<ApiResponse<String>> token_reissue(HttpServletRequest request, HttpServletResponse response){
+        //get refresh token
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("refresh")) {
+
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+            //response status code
+            return ResponseEntity.badRequest().body(ApiResponse.fail(ResponseCode.BAD_REQUEST,"유요한 계정이 아닙니다."));
+        }
+
+        //expired check
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            //response status code
+            return ResponseEntity.badRequest().body(ApiResponse.fail(ResponseCode.BAD_REQUEST,"로그인 시간이 만료되었습니다."));
+        }
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+
+        if (!category.equals("refresh")) {
+
+            //response status code
+            return ResponseEntity.badRequest().body(ApiResponse.fail(ResponseCode.BAD_REQUEST,"유요한 계정이 아닙니다."));
+        }
+
+        //토큰이 DB에 존재하는지 파악
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+
+        //토큰이 존재하지 않는다면,
+        if(!isExist){
+            return ResponseEntity.badRequest().body(ApiResponse.fail(ResponseCode.BAD_REQUEST,"유요한 리프레시 토큰이 아닙니다."));
+        }
+
+        String username = jwtUtil.getUsername(refresh);
+        String role = jwtUtil.getRole(refresh);
+
+        //새로운 토큰 생성
+        String newAccess = jwtUtil.createJwt("access", username, role,600000L);
+        String newRefresh = jwtUtil.createJwt("refresh", username, role,86400000L);
+
+        //기존 refresh 토큰을 DB에서 삭제 후 새로운 refresh 토큰을 저장한다
+        refreshRepository.deleteByRefresh(refresh);
+        RefreshTokenSave(username, newRefresh, 86400000L);
+
+        //response
+        response.setHeader("access", newAccess);
+        response.addCookie(createCookie("refresh",newRefresh));
+
+        return ResponseEntity.ok().body(ApiResponse.success("토큰 재발급이 완료되었습니다."));
+
+    }
+
+
+    //리프레시토큰 저장 로직
+    public void RefreshTokenSave(String username, String refresh,Long expiredMs){
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+        RefreshEntity refreshEntity = new RefreshEntity();
+        refreshEntity.setUsername(username);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
+
+    private Cookie createCookie(String key, String value){
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+}

--- a/src/main/java/com/teamsparta14/order_service/user/service/UserService.java
+++ b/src/main/java/com/teamsparta14/order_service/user/service/UserService.java
@@ -1,0 +1,86 @@
+package com.teamsparta14.order_service.user.service;
+
+import com.teamsparta14.order_service.global.enums.Role;
+import com.teamsparta14.order_service.global.exception.BaseException;
+import com.teamsparta14.order_service.global.response.ApiResponse;
+import com.teamsparta14.order_service.global.response.ResponseCode;
+import com.teamsparta14.order_service.user.dto.UserRequestDTO;
+import com.teamsparta14.order_service.user.dto.UserResponseDTO;
+import com.teamsparta14.order_service.user.entity.UserEntity;
+import com.teamsparta14.order_service.user.jwt.JWTUtil;
+import com.teamsparta14.order_service.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    //유저 회원가입
+    public void user_save(UserRequestDTO userRequestDTO){
+        ModelMapper modelMapper = new ModelMapper();
+
+        //비밀번호 암호화
+        userRequestDTO.setPassword(bCryptPasswordEncoder.encode(userRequestDTO.getPassword()));
+
+        UserEntity userEntity = modelMapper.map(userRequestDTO, UserEntity.class);
+        userEntity.setRole(Role.USER);
+        userRepository.save(userEntity);
+    }
+
+    //관리자 회원가입
+    public void master_save(UserRequestDTO userRequestDTO){
+        ModelMapper modelMapper = new ModelMapper();
+
+        //비밀번호 암호화
+        userRequestDTO.setPassword(bCryptPasswordEncoder.encode(userRequestDTO.getPassword()));
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setRole(Role.MASTER);
+        userEntity = modelMapper.map(userRequestDTO, UserEntity.class);
+        userRepository.save(userEntity);
+    }
+
+    //가게주인 회원가입
+    public void owner_save(UserRequestDTO userRequestDTO){
+        ModelMapper modelMapper = new ModelMapper();
+
+        //비밀번호 암호화
+        userRequestDTO.setPassword(bCryptPasswordEncoder.encode(userRequestDTO.getPassword()));
+
+        UserEntity userEntity = modelMapper.map(userRequestDTO, UserEntity.class);
+        userEntity.setRole(Role.OWNER);
+        userRepository.save(userEntity);
+    }
+
+    //매니저 회원가입
+    public void manager_save(UserRequestDTO userRequestDTO){
+        ModelMapper modelMapper = new ModelMapper();
+
+        //비밀번호 암호화
+        userRequestDTO.setPassword(bCryptPasswordEncoder.encode(userRequestDTO.getPassword()));
+
+        UserEntity userEntity = modelMapper.map(userRequestDTO, UserEntity.class);
+        userEntity.setRole(Role.MANAGER);
+        userRepository.save(userEntity);
+    }
+
+    //user 조회
+    public UserResponseDTO findUser(String username){
+        ModelMapper modelMapper = new ModelMapper();
+        UserEntity userEntity = userRepository.findByUsername(username).orElseThrow(BaseException::new);
+        return modelMapper.map(userEntity,UserResponseDTO.class);
+    }
+
+}


### PR DESCRIPTION
목적 :
- access/refresh 토큰 구현
- 회원가입/로그인/로그아웃/토큰 재발급 구현
- 인증/인가 서비스

목표 :
- jwt 구현
- 필터에서 회원가입, 로그인, 로그아웃, 토큰 재발급 처리완료

달성도 :
- 구현 완료

기타 :
- 배송지 구현 필요
- 회원정보 수정 필요
- 회원탈퇴 구현 필요
- 유저 search 구현 필요 (1명 조회 제외)