### PR TITLE
[Refactor] 가게 삭제 로직 수정 및 토큰 기반 사용자 검증 추가

### DIFF
--- a/src/main/java/com/teamsparta14/order_service/store/controller/StoreController.java
+++ b/src/main/java/com/teamsparta14/order_service/store/controller/StoreController.java
@@ -62,14 +62,13 @@ public class StoreController {
     }
 
     // [POST] 가게 등록
-    @PreAuthorize("hasAnyAuthority('ROLE_MASTER', 'ROLE_ADMIN')")
     @PostMapping("/stores")
     public ResponseEntity<ApiResponse<StoreResponseDto>> createStore(
             @RequestBody StoreRequestDto dto,
             @RequestHeader(name = "access") String token
     ) {
-        // 토큰에서 사용자 이름 추출
         String createdBy = jWTUtil.getUsername(token);
+
         return ResponseEntity.ok(ApiResponse.success(storeService.createStore(dto, createdBy)));
     }
 

--- a/src/main/java/com/teamsparta14/order_service/store/controller/StoreController.java
+++ b/src/main/java/com/teamsparta14/order_service/store/controller/StoreController.java
@@ -137,6 +137,10 @@ public class StoreController {
     ) {
         String role = jWTUtil.getRole(token);
 
+        if (!"ROLE_MASTER".equals(role)) {
+            throw new AccessDeniedException("ROLE_MASTER 권한이 필요합니다.");
+        }
+
         return ResponseEntity.ok(ApiResponse.success(storeService.createCategory(requestDto, role)));
     }
 

--- a/src/main/java/com/teamsparta14/order_service/store/controller/StoreController.java
+++ b/src/main/java/com/teamsparta14/order_service/store/controller/StoreController.java
@@ -12,6 +12,7 @@ import com.teamsparta14.order_service.user.jwt.JWTUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Request;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -33,6 +34,7 @@ import java.util.UUID;
 public class StoreController {
 
     private final StoreService storeService;
+    private final JWTUtil jWTUtil;
 
     // [GET] 전체 가게 조회
     @GetMapping("/stores")
@@ -64,10 +66,11 @@ public class StoreController {
     @PostMapping("/stores")
     public ResponseEntity<ApiResponse<StoreResponseDto>> createStore(
             @RequestBody StoreRequestDto dto,
-            @AuthenticationPrincipal CustomUserDetails customUserDetails
+            @RequestHeader(name = "access") String token
     ) {
-
-        return ResponseEntity.ok(ApiResponse.success(storeService.createStore(dto)));
+        // 토큰에서 사용자 이름 추출
+        String createdBy = jWTUtil.getUsername(token);
+        return ResponseEntity.ok(ApiResponse.success(storeService.createStore(dto, createdBy)));
     }
 
     // [PUT] 가게 정보 수정
@@ -128,31 +131,58 @@ public class StoreController {
     }
 
     // [등록] 카테고리
-    @PreAuthorize("hasAnyAuthority('ROLE_MASTER')")
     @PostMapping("/categories")
-    public ResponseEntity<ApiResponse<CategoryResponseDto>> createCategory(@RequestBody CategoryRequestDto requestDto) {
-        return ResponseEntity.ok(ApiResponse.success(storeService.createCategory(requestDto)));
+    public ResponseEntity<ApiResponse<CategoryResponseDto>> createCategory(
+            @RequestBody CategoryRequestDto requestDto,
+            @RequestHeader(name = "access") String token
+    ) {
+        String role = jWTUtil.getRole(token);
+
+        return ResponseEntity.ok(ApiResponse.success(storeService.createCategory(requestDto, role)));
     }
 
     // [수정] 카테고리
-    @PreAuthorize("hasAnyAuthority('ROLE_MASTER')")
     @PutMapping("/categories/{categoryId}")
-    public ResponseEntity<ApiResponse<CategoryResponseDto>> updateCategory(@PathVariable UUID categoryId, @RequestBody CategoryRequestDto requestDto) {
-        return ResponseEntity.ok(ApiResponse.success(storeService.updateCategory(categoryId, requestDto)));
+    public ResponseEntity<ApiResponse<CategoryResponseDto>> updateCategory(
+            @PathVariable UUID categoryId,
+            @RequestBody CategoryRequestDto requestDto,
+            @RequestHeader(name = "access") String token
+    ) {
+        String role = jWTUtil.getRole(token);
+        if (!"ROLE_MASTER".equals(role)) {
+            throw new AccessDeniedException("ROLE_MASTER 권한이 필요합니다.");
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(storeService.updateCategory(categoryId, requestDto, role)));
     }
 
     // [삭제] 카테고리
-    @PreAuthorize("hasAnyAuthority('ROLE_MASTER')")
     @DeleteMapping("/categories/{categoryId}")
-    public ResponseEntity<ApiResponse<String>> deleteCategory(@PathVariable UUID categoryId) {
-        return ResponseEntity.ok(ApiResponse.success(storeService.deleteCategory(categoryId)));
+    public ResponseEntity<ApiResponse<String>> deleteCategory(
+            @PathVariable UUID categoryId,
+            @RequestHeader(name = "access") String token
+    ) {
+        String role = jWTUtil.getRole(token);
+        if (!"ROLE_MASTER".equals(role)) {
+            throw new AccessDeniedException("ROLE_MASTER 권한이 필요합니다.");
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(storeService.deleteCategory(categoryId, role)));
     }
 
     // [등록] 지역
-    @PreAuthorize("hasAuthority('ROLE_MASTER')")
     @PostMapping("/regions")
-    public ResponseEntity<ApiResponse<RegionResponseDto>> createRegion(@RequestBody RegionRequestDto requestDto) {
-        return ResponseEntity.ok(ApiResponse.success(storeService.createRegion(requestDto)));
+    public ResponseEntity<ApiResponse<RegionResponseDto>> createRegion(
+            @RequestBody RegionRequestDto requestDto,
+            @RequestHeader(name = "access") String token
+    ) {
+        String role = jWTUtil.getRole(token);
+
+        if (!"ROLE_MASTER".equals(role)) {
+            throw new AccessDeniedException("ROLE_MASTER 권한이 필요합니다.");
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(storeService.createRegion(requestDto, role)));
     }
 
     // [수정] 리뷰 점수

--- a/src/main/java/com/teamsparta14/order_service/store/dto/RegionRequestDto.java
+++ b/src/main/java/com/teamsparta14/order_service/store/dto/RegionRequestDto.java
@@ -1,10 +1,14 @@
 package com.teamsparta14.order_service.store.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class RegionRequestDto {
     private String regionName;
 }

--- a/src/main/java/com/teamsparta14/order_service/store/dto/RegionResponseDto.java
+++ b/src/main/java/com/teamsparta14/order_service/store/dto/RegionResponseDto.java
@@ -1,11 +1,13 @@
 package com.teamsparta14.order_service.store.dto;
 
 import com.teamsparta14.order_service.store.entity.Region;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.UUID;
 
 @Getter
+@AllArgsConstructor
 public class RegionResponseDto {
     private UUID id;
     private String regionName;

--- a/src/main/java/com/teamsparta14/order_service/store/dto/StoreRequestDto.java
+++ b/src/main/java/com/teamsparta14/order_service/store/dto/StoreRequestDto.java
@@ -1,5 +1,6 @@
 package com.teamsparta14.order_service.store.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 import com.teamsparta14.order_service.store.entity.StoreStatus;
@@ -11,7 +12,9 @@ public class StoreRequestDto {
     private String storeName;
     private String address;
     private String phone;
+    private String regionName;
+    private StoreStatus status = StoreStatus.OPEN;
+
+    @JsonProperty("categoryName")
     private List<String> categories;
-    private String regionName; // 지역 추가
-    private StoreStatus status = StoreStatus.OPEN; // 기본값 설정
 }

--- a/src/main/java/com/teamsparta14/order_service/store/service/StoreService.java
+++ b/src/main/java/com/teamsparta14/order_service/store/service/StoreService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,7 @@ public class StoreService {
     private final StoreCategoryRepository storeCategoryRepository;
     private final CategoryRepository categoryRepository;
     private final RegionRepository regionRepository;
+    private final JWTUtil jwtUtil;
 
     // [조회] 가게
     public Page<StoreResponseDto> getAllStores(Pageable pageable, StoreStatus status) {
@@ -54,8 +56,9 @@ public class StoreService {
 
     // [등록] 가게
     @Transactional
-    public StoreResponseDto createStore(StoreRequestDto dto) {
+    public StoreResponseDto createStore(StoreRequestDto dto, String token) {
 
+        String currentUsername = jwtUtil.getUsername(token);
         Region region = regionRepository.findByRegionName(dto.getRegionName())
                 .orElseThrow(() -> new RuntimeException("해당 지역을 찾을 수 없습니다: " + dto.getRegionName()));
 
@@ -68,6 +71,7 @@ public class StoreService {
                 .region(region)
                 .build();
 
+        store.setCreatedBy(currentUsername);
         Store savedStore = storeRepository.save(store);
         saveStoreCategories(savedStore, dto.getCategories());
 
@@ -111,7 +115,7 @@ public class StoreService {
                 .collect(Collectors.toList());
     }
 
-    // [등록] 카테고리 저장
+    // [등록] 가게와 카테고리 저장
     private void saveStoreCategories(Store store, List<String> categoryNames) {
         List<Category> categories = categoryRepository.findByCategoryNameIn(categoryNames);
         List<StoreCategory> storeCategories = categories.stream()
@@ -136,9 +140,12 @@ public class StoreService {
 
     // [등록] 카테고리
     @Transactional
-    public CategoryResponseDto createCategory(CategoryRequestDto dto) {
+    public CategoryResponseDto createCategory(CategoryRequestDto dto, String role) {
 
-        // 카테고리 중복 체크
+        if ("ROLE_OWNER".equals(role)) {
+            throw new IllegalArgumentException("권한이 없습니다. 카테고리를 등록할 수 없습니다.");
+        }
+
         boolean exists = categoryRepository.existsByCategoryName(dto.getCategoryName());
         if (exists) {
             throw new IllegalArgumentException("이미 존재하는 카테고리입니다.");
@@ -154,33 +161,50 @@ public class StoreService {
 
     // [수정] 카테고리
     @Transactional
-    public CategoryResponseDto updateCategory(UUID categoryId, CategoryRequestDto dto) {
+    public CategoryResponseDto updateCategory(UUID categoryId, CategoryRequestDto dto, String role) {
+
+        if ("ROLE_OWNER".equals(role)) {
+            throw new IllegalArgumentException("권한이 없습니다. 카테고리를 수정할 수 없습니다.");
+        }
+
         Category category = categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new RuntimeException("해당 카테고리를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리를 찾을 수 없습니다."));
+
         category.setCategoryName(dto.getCategoryName());
         return new CategoryResponseDto(categoryRepository.save(category));
     }
 
     // [삭제] 카테고리
     @Transactional
-    public String deleteCategory(UUID categoryId) {
+    public String deleteCategory(UUID categoryId, String role) {
+
         if (!categoryRepository.existsById(categoryId)) {
-            throw new RuntimeException("해당 카테고리를 찾을 수 없습니다.");
+            throw new IllegalArgumentException("해당 카테고리를 찾을 수 없습니다.");
         }
+
+        if ("ROLE_OWNER".equals(role)) {
+            throw new IllegalArgumentException("권한이 없습니다. 카테고리를 삭제할 수 없습니다.");
+        }
+
         categoryRepository.deleteById(categoryId);
         return "카테고리 ID " + categoryId + "가 성공적으로 삭제되었습니다.";
     }
 
     // [등록] 지역
     @Transactional
-    public RegionResponseDto createRegion(RegionRequestDto requestDto) {
-        boolean exists = regionRepository.existsByRegionName(requestDto.getRegionName());
+    public RegionResponseDto createRegion(RegionRequestDto dto, String role) {
+
+        if ("ROLE_OWNER".equals(role)) {
+            throw new IllegalArgumentException("권한이 없습니다. 지역을 등록할 수 없습니다.");
+        }
+
+        boolean exists = regionRepository.existsByRegionName(dto.getRegionName());
         if (exists) {
             throw new IllegalArgumentException("이미 존재하는 지역입니다.");
         }
 
         Region region = Region.builder()
-                .regionName(requestDto.getRegionName())
+                .regionName(dto.getRegionName())
                 .build();
 
         Region savedRegion = regionRepository.save(region);

--- a/src/main/java/com/teamsparta14/order_service/store/service/StoreService.java
+++ b/src/main/java/com/teamsparta14/order_service/store/service/StoreService.java
@@ -137,8 +137,6 @@ public class StoreService {
         return storeCategoryRepository.saveAll(storeCategories);
     }
 
-
-
     // [조회] 모든 카테고리
     public List<CategoryResponseDto> getAllCategories() {
         return categoryRepository.findAll().stream()
@@ -157,10 +155,6 @@ public class StoreService {
     @Transactional
     public CategoryResponseDto createCategory(CategoryRequestDto dto, String role) {
 
-        if ("ROLE_OWNER".equals(role)) {
-            throw new IllegalArgumentException("권한이 없습니다. 카테고리를 등록할 수 없습니다.");
-        }
-
         boolean exists = categoryRepository.existsByCategoryName(dto.getCategoryName());
         if (exists) {
             throw new IllegalArgumentException("이미 존재하는 카테고리입니다.");
@@ -178,10 +172,6 @@ public class StoreService {
     @Transactional
     public CategoryResponseDto updateCategory(UUID categoryId, CategoryRequestDto dto, String role) {
 
-        if ("ROLE_OWNER".equals(role)) {
-            throw new IllegalArgumentException("권한이 없습니다. 카테고리를 수정할 수 없습니다.");
-        }
-
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 카테고리를 찾을 수 없습니다."));
 
@@ -197,10 +187,6 @@ public class StoreService {
             throw new IllegalArgumentException("해당 카테고리를 찾을 수 없습니다.");
         }
 
-        if ("ROLE_OWNER".equals(role)) {
-            throw new IllegalArgumentException("권한이 없습니다. 카테고리를 삭제할 수 없습니다.");
-        }
-
         categoryRepository.deleteById(categoryId);
         return "카테고리 ID " + categoryId + "가 성공적으로 삭제되었습니다.";
     }
@@ -208,10 +194,6 @@ public class StoreService {
     // [등록] 지역
     @Transactional
     public RegionResponseDto createRegion(RegionRequestDto dto, String role) {
-
-        if ("ROLE_OWNER".equals(role)) {
-            throw new IllegalArgumentException("권한이 없습니다. 지역을 등록할 수 없습니다.");
-        }
 
         boolean exists = regionRepository.existsByRegionName(dto.getRegionName());
         if (exists) {


### PR DESCRIPTION
[Refactor] 가게 삭제 로직 수정 및 토큰 기반 사용자 검증 추가

[변경 이유]
- 기존 `Store.getCreatedBy()` 직접 참조 방식에서 `storeService.getStoreById(storeId)`를 통해 가게 정보를 가져오도록 변경
- ROLE_MASTER만 모든 가게를 삭제 가능하도록 권한 검증 추가
- ROLE_OWNER는 본인이 생성한 가게만 삭제 가능하도록 제한

[변경 사항]
1. JWT 기반 사용자 검증 추가
   - jWTUtil.getUsername(token), jWTUtil.getRole(token)
   - `ROLE_MASTER`가 아닌 경우, 본인이 생성한 가게만 삭제 가능하도록 예외 처리 추가

2. deleteStore()서비스 개선
   - IllegalStateException 예외 처리
   - ROLE_MASTER는 모든 가게 삭제 가능, ROLE_OWNER는 본인이 생성한 가게만 삭제 가능하도록 로직 변경
   - AccessDeniedException

[추가 진행 업무]
- controller에서 권한 확인하는데 괜찮은지 확인 필요
- 리뷰 검증 update 확인 필요
- 발표 자료 작성
- 브랜치 이름 이상..
