### PR TITLE
[Feature] SecurityConfig에 product, review 페이지 접근 권한 설정 추가

### DIFF
--- a/src/main/java/com/teamsparta14/order_service/config/SecurityConfig.java
+++ b/src/main/java/com/teamsparta14/order_service/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -77,6 +78,11 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/join/**", "/api/auth/login","/swagger-ui/**","/swagger-resources/**","/v3/api-docs/**").permitAll()  // 회원가입은 인증 없이 가능
                         .requestMatchers("/api/address/**", "/api/auth/delete").hasRole("USER")
                         .requestMatchers("/api/user/list/{username}").hasRole("MASTER")
+                        .requestMatchers(HttpMethod.GET,"/api/products/**").permitAll()
+                        .requestMatchers(HttpMethod.POST,"/api/products/search").permitAll()
+                        .requestMatchers("/api/products/**").hasAnyRole("OWNER","MASTER")
+                        .requestMatchers(HttpMethod.GET,"/api/reviews/**").permitAll()
+                        .requestMatchers("/api/revies/**").hasRole("USER")
                         .anyRequest().authenticated()  // 그 외 모든 요청은 인증 필요
 //                        .anyRequest().permitAll()  // 그 외 모든 요청은 인증 필요
                 )


### PR DESCRIPTION
[목적]: 권한에 따라 페이지 별 접근 통제하기 위함

[목표]: 리스트 조회는 공개, 상품 추가수정삭제 등 변경사항은 Owner와 Master만 접근, 리뷰는 User(구매한)만 가능하도록 설정

[달성도]:
  - SecuritConfig 페이지 경로 별 권한 설정 완료

[기타]: