### PR TITLE
[refactor]: StoreService 권한 검증 로직 통합 및 중복 제거

### DIFF
--- a/src/main/java/com/teamsparta14/order_service/store/controller/StoreController.java
+++ b/src/main/java/com/teamsparta14/order_service/store/controller/StoreController.java
@@ -44,7 +44,6 @@ public class StoreController {
     }
 
     // [GET] 특정 가게 조회
-
     @GetMapping("/stores/{storeId}")
     public ResponseEntity<ApiResponse<StoreResponseDto>> getStore(@PathVariable(name = "storeId") UUID storeId,@RequestHeader("access") String token) {
         Store store = storeService.getStoreById(storeId , token);


### PR DESCRIPTION
[refactor]
- StoreService 권한 체크 중복 해결

[목적]
- 중복된 권한 검증 로직을 하나의 메서드로 통합

[목표]
- validateRole() 메서드 추가 및 기존 권한 체크 로직 제거

[달성도]
  - 권한 체크 로직 중복 제거 완료
  - 가게 등록/삭제 local환경에서 API 테스트 오나료

[기타]
- Region과 Address 중복 문제 해결 예정(Address 등록하면 자동으로 주소 뽑아내도록)
- 가게 이름 중복 안되게 처리 예정
